### PR TITLE
Fixed iPhone 6 Plus splash file names

### DIFF
--- a/index.php
+++ b/index.php
@@ -228,8 +228,8 @@ if ( $_SERVER['REQUEST_METHOD'] == 'POST' ) {
 					
 					// iPhone 6
 					$sizes[] = array( $ios_path . '/Default-667h@2x.png', 750, 1334, 72 );
-					$sizes[] = array( $ios_path . '/Default-Portrait-736@3x.png', 1242, 2208, 72 );
-					$sizes[] = array( $ios_path . '/Default-Landscape-736@3x.png', 2208, 1242, 72 );
+					$sizes[] = array( $ios_path . '/Default-Portrait-736h@3x.png', 1242, 2208, 72 );
+					$sizes[] = array( $ios_path . '/Default-Landscape-736h@3x.png', 2208, 1242, 72 );
 				}
 
 				// iPad


### PR DESCRIPTION
Titanium doesn't consider Default-Portrait-736@3x.png and Default-Landscape-736@3x.png names (_without_ the trailing "h" after "736")  to be valid, and it doesn't reference them in the generated info.plist file. This should fix the issue
